### PR TITLE
Adding the ability to pass in a cidr to the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,21 @@ ipSet.add(exampleBlockedIP2)
 var isBlocked = ipSet.contains(exampleBlockedIP2) // isBlocked will be true
 ```
 
+CIDR ip's are also supported
+
+```js
+ipSet.add(`192.168.1.0/24`);
+var isBlockedInList= ipSet.contains('192.168.1.0');// isBlockedInList will be true
+isBlockedInList= ipSet.contains('192.168.1.255');// isBlockedInList will be true
+```
+  
+
 ## todo
 (prioritized highest to lowest)
 
 - [x] Port IPv4 implementation from `torrent-stream`
 - [x] Add basic tests
+- [x] Support CIDR notation
 - [ ] Support IPv6
 - [ ] Investigate potential use of [node-iptrie](https://github.com/postwait/node-iptrie)
 

--- a/index.js
+++ b/index.js
@@ -122,8 +122,14 @@ module.exports = function (blocklist) {
       start = start.start
     }
 
+    var cidrStr = /\/\d{1,2}/;
+    if (typeof start === 'string' && cidrStr.test(start)) {
+      var ipSubnet = ip.cidrSubnet(start);
+      start = ipSubnet.networkAddress;
+      end = ipSubnet.broadcastAddress;
+    }
     if (typeof start !== 'number') start = ip.toLong(start)
-
+    
     if (!end) end = start
     if (typeof end !== 'number') end = ip.toLong(end)
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ip": "^1.1.3"
   },
   "devDependencies": {
+    "mocha": "^5.2.0",
     "tape": "^4.6.0"
   },
   "homepage": "http://webtorrent.io",

--- a/test/basic.js
+++ b/test/basic.js
@@ -25,6 +25,20 @@ test('ipSet.contains respects ipSet.add with a start and an end', function(t) {
   t.end()
 });
 
+test('ipSet.contains respects ipSet.add with a cidr', function(t) {
+  const set = ipSet();
+  const cidrIp = '192.168.1.0/24';
+  
+  set.add(cidrIp);
+  t.ok(set.contains('192.168.1.0'))
+  t.ok(set.contains('192.168.1.5'))
+  t.ok(set.contains('192.168.1.255'))
+  t.ok(set.contains('192.168.1.123'))
+  t.notOk(set.contains('192.168.2.0'))
+
+  t.end()
+});
+
 test('IPv6', function(t) {
   const set = ipSet();
   const ip = '0:0:0:0:0:ffff:7f00:1' // 127.0.0.1


### PR DESCRIPTION
I have a use case where i would like to be able to pass in a cidr to the tree but it seems that functionality may not currently be supported... so i wrote some 👍 

I added a unit test with some assertions to hopefully give context to the change. I may need to update the README as well at some point.