### PR TITLE
fix: replace ip with ip-address package to remove the high vulnerability…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.2.0",
   "author": "Travis Fischer <fisch0920@gmail.com>",
   "dependencies": {
-    "ip": "^2.0.1"
+    "ip-address": "^10.0.1"
   },
   "devDependencies": {
     "standard": "^16.0.2",


### PR DESCRIPTION
… warning

@transitive-bullshit thanks for providing this lib. Unfortunately the [ip](https://github.com/indutny/node-ip) package has become less maintained and will probably not solve the [vulnerability around the isPrivate function](https://github.com/indutny/node-ip/issues/150). Even if you are not using the isPrivate function in your codebase, your library is marked by npm as vulnerable due to the usage of [ip](https://github.com/indutny/node-ip). 

I replaced the ip package with [ip-address](https://www.npmjs.com/package/ip-address) which is also recommended in the thread of [ip issue 150](https://github.com/indutny/node-ip/issues/150). 

I did run the test, all 17 passed and the vulnerability warning went away.

Let me know if you need any more information. 

Thanks,
Fabian